### PR TITLE
chore: establish GitHub branch/issue governance (#1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a defect or unexpected behavior
+title: "fix: <short description>"
+labels: ["bug"]
+assignees: miyanoritallest-afk
+---
+
+## Summary
+<!-- One-sentence description of the bug -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should happen -->
+
+## Actual Behavior
+<!-- What actually happens -->
+
+## Environment
+- Browser / OS:
+- Backend version (git SHA or tag):
+- Java version: 21
+- Docker Compose running: yes / no
+
+## Logs / Screenshots
+<!-- Paste relevant Spring Boot logs or browser console errors -->
+
+## Proposed Fix (optional)
+<!-- If you have an idea how to fix it -->

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,23 @@
+---
+name: Chore / Infrastructure
+about: Tooling, dependency updates, CI, refactoring, configuration
+title: "chore: <short description>"
+labels: ["chore"]
+assignees: miyanoritallest-afk
+---
+
+## Summary
+<!-- What needs to be done and why -->
+
+## Scope
+- [ ] Dependencies
+- [ ] Build / Gradle / npm
+- [ ] Docker / Infrastructure
+- [ ] CI / GitHub Actions
+- [ ] Configuration / Environment
+- [ ] Code refactoring
+- [ ] Documentation
+
+## Definition of Done
+- [ ] 
+- [ ] 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement
+title: "feat: <short description>"
+labels: ["enhancement"]
+assignees: miyanoritallest-afk
+---
+
+## Feature Summary
+<!-- One-sentence description of the feature -->
+
+## Development Phase
+<!-- Which phase does this belong to? Phase 1 / 2 / 3 / 4 / post-MVP -->
+Phase: 
+
+## Motivation
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Acceptance Criteria
+<!-- Check these off as you implement -->
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Technical Notes (optional)
+<!-- Any implementation hints, affected files, API changes, DB migration needed -->
+
+## Related Issues
+<!-- #<number> -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+<!-- What does this PR do? 1-3 sentences -->
+
+## Closes
+<!-- REQUIRED: Link to the issue this PR resolves -->
+Closes #
+
+## Type of Change
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] chore — tooling / config / deps
+- [ ] docs — documentation only
+- [ ] refactor — no behavior change
+- [ ] test — tests only
+
+## Changes Made
+<!-- Bullet list of notable changes -->
+- 
+
+## Testing
+<!-- How was this tested? Check all that apply -->
+- [ ] Local Docker Compose stack (`docker compose up -d`)
+- [ ] Backend started (`./gradlew bootRun`) — no startup errors
+- [ ] Frontend started (`npm run dev`) — visual check
+- [ ] Relevant API endpoints tested manually (curl / browser)
+- [ ] Existing behavior not broken
+
+## DB Migrations
+- [ ] No DB changes
+- [ ] New Flyway migration added: `V<N>__<description>.sql`
+
+## Screenshots (if UI change)
+<!-- Before / After screenshots or screen recording -->
+
+## Notes for Reviewer
+<!-- Anything the reviewer should pay special attention to -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md — Task Management App: Claude Code Rules
+
+## Project Overview
+Spring Boot 4 (Java 21, Gradle) backend + React 18 (Vite) frontend.
+Kanban board app. See `docs/` for requirements and architecture.
+
+## Mandatory Workflow — Follow Without Exception
+
+### 1. GitHub Issue First
+Before writing ANY code or creating ANY branch:
+- Check if a GitHub Issue exists: `gh issue list`
+- If no issue exists, create one FIRST: `gh issue create --title "..." --body "..." --label "..."`
+- Record the issue number. All subsequent steps reference it.
+
+### 2. Branch Naming
+Branches MUST follow this pattern: `<type>/issue-<number>-<short-slug>`
+
+| Prefix | Use for |
+|--------|---------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `chore/` | Tooling, deps, CI, config |
+| `docs/` | Documentation only |
+| `refactor/` | Code restructuring, no behavior change |
+| `test/` | Adding or fixing tests |
+
+Examples:
+- `feature/issue-12-card-drag-drop`
+- `fix/issue-7-column-sort-crash`
+- `docs/issue-3-api-reference`
+
+Create branch: `git checkout -b <type>/issue-<N>-<slug>`
+
+### 3. No Direct Push to Main
+NEVER run `git push origin main` or commit directly to main.
+Main is protected. All changes go through Pull Requests.
+
+### 4. Commit Messages
+Format: `<type>(<scope>): <short description> (#<issue-number>)`
+
+Examples:
+- `feat(backend): add Card priority field (#5)`
+- `fix(frontend): correct column sort order (#8)`
+- `chore(docker): add healthcheck to postgres service (#2)`
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`
+
+### 5. Pull Request Process
+1. Push branch: `git push -u origin <branch-name>`
+2. Create PR: `gh pr create --fill`
+3. PR title format: `<type>: <description> (#<issue-number>)`
+4. Ensure PR body contains `Closes #<N>`
+5. After merge, delete branch: `git branch -d <branch-name>`
+
+## Local Development Commands
+```bash
+# Start PostgreSQL
+docker compose up -d
+
+# Backend (from backend/)
+./gradlew bootRun
+
+# Frontend (from frontend/ — when created)
+npm run dev
+```
+
+## Key Paths
+- Backend source: `backend/src/main/java/com/taskmanagement/backend/`
+- DB migrations: `backend/src/main/resources/db/migration/`
+- Requirements docs: `docs/`
+- Docker config: `docker-compose.yml`, `backend/Dockerfile`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing Guide
+
+This is a solo learning project. These rules exist to build good habits and keep the git history clean.
+
+## The Golden Rules
+
+1. **Issue first, code second.** Every piece of work begins with a GitHub Issue.
+2. **No direct commits to `main`.** Ever. Use a branch and a PR.
+3. **One issue, one branch, one PR.** Keep scope tight.
+
+## Step-by-Step Workflow
+
+### Step 1: Create or find an Issue
+
+```bash
+# List open issues
+gh issue list
+
+# Create a new issue
+gh issue create --title "feat: add card due date display" --label "enhancement"
+```
+
+Note the issue number (e.g., `#12`).
+
+### Step 2: Create a branch
+
+Branch naming: `<type>/issue-<number>-<slug>`
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/issue-12-card-due-date
+```
+
+| Prefix | When to use |
+|--------|-------------|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `chore/` | Build, deps, infra, config |
+| `docs/` | Documentation |
+| `refactor/` | Restructuring, no behavior change |
+| `test/` | Test additions only |
+
+### Step 3: Write code and commit
+
+Commit format: `<type>(<scope>): <description> (#<issue-number>)`
+
+```bash
+git add backend/src/...
+git commit -m "feat(backend): add dueDate field to Card entity (#12)"
+```
+
+### Step 4: Push and open a PR
+
+```bash
+git push -u origin feature/issue-12-card-due-date
+gh pr create --fill
+```
+
+Fill in the PR template. The `Closes #12` line in the body automatically closes the issue when the PR merges.
+
+### Step 5: Merge and clean up
+
+```bash
+# After merge on GitHub:
+git checkout main
+git pull origin main
+git branch -d feature/issue-12-card-due-date
+```
+
+## Commit Message Types
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `chore` | Tooling, deps, CI |
+| `docs` | Documentation |
+| `refactor` | Restructuring |
+| `test` | Test-only changes |
+| `style` | Formatting, whitespace |
+
+## Labels
+
+| Label | Meaning |
+|-------|---------|
+| `bug` | Something is broken |
+| `enhancement` | New feature or improvement |
+| `chore` | Infrastructure, tooling |
+| `docs` | Documentation |
+| `phase-1` through `phase-4` | Development phase tag |
+
+## Local Development
+
+```bash
+# 1. Start PostgreSQL
+docker compose up -d
+
+# 2. Start backend (from backend/)
+./gradlew bootRun
+
+# 3. Start frontend (from frontend/ — Phase 1+)
+npm run dev
+```
+
+- Backend API: `http://localhost:8080`
+- Frontend: `http://localhost:5173`
+- PostgreSQL: `localhost:5432`, database `kanban_db`


### PR DESCRIPTION
## Summary
CLAUDE.md、.github/テンプレート、ブランチ保護、コントリビューションガイドを設定し、GitHub運用ルールを確立する。

## Closes
Closes #1

## Type of Change
- [x] chore — tooling / config / deps

## Changes Made
- `CLAUDE.md` を追加 — Claude Codeが毎回読む必須ワークフロールール
- `.github/ISSUE_TEMPLATE/` に bug_report / feature_request / chore テンプレートを追加
- `.github/pull_request_template.md` を追加
- `CONTRIBUTING.md` を追加
- GitHub API でmainブランチ保護を設定（force push禁止、PR必須）
- マージ方式をスカッシュのみに統一、マージ後ブランチ自動削除を有効化
- ラベル phase-1〜4 / chore / refactor を作成

## Testing
- [x] ブランチ保護がGitHub Settings > Branchesで確認済み
- [x] ラベルが `gh label list` で確認済み

## DB Migrations
- [x] No DB changes