### PR TITLE
chore: fix .gitignore, update tech-stack.md, add root README (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# Task Management App
+
+Trello スタイルの Kanban ボードアプリ。Spring Boot 4 + React 19 で構築。
+タスクを **Todo / In Progress / Done** の3カラムにカードとして管理する。
+
+## 機能概要
+
+- カラムへのカード追加（タイトル・優先度 High/Medium/Low/None）
+- カラム間のカード移動（フェーズ1: 矢印ボタン、フェーズ3: ドラッグ&ドロップ）
+- カードタイトルのインライン編集・詳細モーダル（フェーズ2）
+- 優先度・期限日によるカード並び替え
+- 全データを PostgreSQL に永続化（Spring Boot REST API 経由）
+
+13のユースケース・4フェーズの全機能一覧は [docs/features.md](docs/features.md) を参照。
+
+## 技術スタック
+
+| レイヤー | 技術 | バージョン |
+|---------|------|-----------|
+| 言語（バックエンド） | Java | 21 LTS |
+| バックエンド | Spring Boot | 4.0.0 |
+| ビルドツール | Gradle | 8.14 |
+| DB マイグレーション | Flyway | 11.3.0 |
+| PostgreSQL JDBC | postgresql | 42.7.4 |
+| UI ライブラリ | React | 19.2.5 |
+| フロントエンドビルド | Vite | 8.0.10 |
+| 言語（フロントエンド） | TypeScript | 6.0.3 |
+| HTTP クライアント | Axios | 1.15.2 |
+| データベース | PostgreSQL | 16（Docker） |
+
+採用理由・アーキテクチャ詳細は [docs/tech-stack.md](docs/tech-stack.md) を参照。
+
+## 必要な環境
+
+- **Java 21**（JDK — `./gradlew` が使用）
+- **Node.js 20+** と **npm**
+- **Docker**（Docker Compose で PostgreSQL を起動）
+- **Git**
+
+## ローカル開発セットアップ
+
+### 1. PostgreSQL を起動
+
+```bash
+docker compose up -d
+```
+
+`docker-compose.yml` の設定で PostgreSQL 16 をポート 5432 で起動する。
+
+### 2. バックエンドを起動
+
+```bash
+cd backend
+./gradlew bootRun
+```
+
+API は `http://localhost:8080` で利用可能。起動時に Flyway が DB マイグレーションを自動実行する。
+
+### 3. フロントエンドを起動
+
+```bash
+cd frontend
+npm install   # 初回のみ
+npm run dev
+```
+
+UI は `http://localhost:5173` で利用可能。Vite が `/api/*` リクエストをバックエンド（8080）へプロキシする。
+
+### ポート一覧
+
+| サービス | ポート | 設定ファイル |
+|---------|------|------------|
+| PostgreSQL | 5432 | `docker-compose.yml` |
+| バックエンド（Spring Boot） | 8080 | `backend/src/main/resources/application.properties` |
+| フロントエンド（Vite） | 5173 | Vite デフォルト |
+
+ポートは固定。変更不可。Vite プロキシと Spring Boot CORS 設定がこの値に依存している。
+ポート競合時の解消手順は [CLAUDE.md](CLAUDE.md) を参照。
+
+## プロジェクト構造
+
+```
+TaskuManegement/
+├── backend/                        # Spring Boot 4 アプリケーション
+│   ├── src/main/java/              # Java ソース（controllers, services, repositories）
+│   ├── src/main/resources/
+│   │   ├── application.properties
+│   │   └── db/migration/           # Flyway SQL マイグレーション（V1__, V2__, ...）
+│   ├── build.gradle.kts
+│   └── Dockerfile
+├── frontend/                       # React 19 + Vite 8 アプリケーション
+│   ├── src/                        # TypeScript ソース（components, contexts, api）
+│   ├── vite.config.js              # Vite 設定 + /api プロキシ → :8080
+│   └── package.json
+├── docs/                           # プロジェクトドキュメント
+├── docker-compose.yml              # PostgreSQL + バックエンド定義
+└── CLAUDE.md                       # 開発ワークフロールール
+```
+
+## ドキュメント
+
+| ドキュメント | 内容 |
+|------------|------|
+| [docs/requirements.md](docs/requirements.md) | プロジェクト概要・背景 |
+| [docs/features.md](docs/features.md) | 4フェーズ・13ユースケースの機能一覧 |
+| [docs/data-model.md](docs/data-model.md) | ER 図・テーブル定義（boards, columns, cards） |
+| [docs/screens.md](docs/screens.md) | UI 仕様・画面遷移 |
+| [docs/non-functional.md](docs/non-functional.md) | パフォーマンス・ブラウザ対応・アクセシビリティ |
+| [docs/tech-stack.md](docs/tech-stack.md) | 技術スタック詳細（バージョン・採用理由） |
+| [CLAUDE.md](CLAUDE.md) | Git ワークフロー・コミット形式・ポートルール |
+
+## データモデル
+
+3テーブルの親子階層構造：
+
+```
+boards (1) ──< columns (N) ──< cards (N)
+```
+
+`card` の主なフィールド: `title`, `description`, `due_date`, `priority`（high/medium/low/none）, `color`, `position`
+
+詳細は [docs/data-model.md](docs/data-model.md) の ER 図を参照。

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -4,36 +4,39 @@
 
 ### バックエンド
 
-| 役割 | 技術 |
-|------|------|
-| 言語 | Java 21 LTS |
-| フレームワーク | Spring Boot 3.3.x |
-| ビルドツール | Maven |
-| ORM | Spring Data JPA + Hibernate |
-| DB マイグレーション | Flyway |
-| バリデーション | spring-boot-starter-validation（Jakarta Validation 3.x） |
-| JDBC ドライバ | PostgreSQL JDBC Driver |
-| コネクションプール | HikariCP（Spring Boot 同梱） |
+| 役割 | 技術 | バージョン |
+|------|------|-----------|
+| 言語 | Java | 21 LTS |
+| フレームワーク | Spring Boot | 4.0.0 |
+| ビルドツール | Gradle | 8.14 |
+| ORM | Spring Data JPA + Hibernate | Spring Boot 4 管理 |
+| DB マイグレーション | Flyway | 11.3.0 |
+| バリデーション | spring-boot-starter-validation | Spring Boot 4 管理 |
+| JDBC ドライバ | PostgreSQL JDBC Driver | 42.7.4 |
+| コネクションプール | HikariCP | Spring Boot 4 同梱 |
+| JSON シリアライズ | jackson-datatype-jsr310 | Spring Boot 4 管理 |
+| テスト用 DB | H2 | Spring Boot 4 管理 |
 
 ### フロントエンド
 
-| 役割 | 技術 |
-|------|------|
-| UI ライブラリ | React 18.x |
-| ビルドツール | Vite 5.x |
-| HTTP クライアント | Axios |
-| 状態管理 | useState + Context API |
-| ルーティング | React Router v6 |
-| ドラッグ&ドロップ | @hello-pangea/dnd（フェーズ3で導入） |
-| スタイリング | CSS Modules |
-| トースト通知 | react-hot-toast |
+| 役割 | 技術 | バージョン |
+|------|------|-----------|
+| UI ライブラリ | React | 19.2.5 |
+| ビルドツール | Vite | 8.0.10 |
+| 言語 | TypeScript | 6.0.3 |
+| HTTP クライアント | Axios | 1.15.2 |
+| 状態管理 | useState + Context API | — |
+| ドラッグ&ドロップ | @hello-pangea/dnd | フェーズ3で導入 |
+| スタイリング | CSS Modules | — |
+| Vite プラグイン | @vitejs/plugin-react | 6.0.1 |
+| リンター | ESLint | 10.2.1 |
 
 ### インフラ（ローカル開発）
 
-| 役割 | 技術 |
-|------|------|
-| データベース | PostgreSQL 16 |
-| DB 起動方法 | Docker Compose |
+| 役割 | 技術 | バージョン |
+|------|------|-----------|
+| データベース | PostgreSQL | 16 |
+| DB 起動方法 | Docker Compose | — |
 
 ---
 
@@ -43,26 +46,25 @@
 
 #### Java 21 LTS
 - 最新の長期サポート（LTS）バージョン
-- Spring Boot 3.3.x との相性が最も良い
+- Spring Boot 4.0.0 との相性が最も良い
 
-#### Spring Boot 3.3.x
+#### Spring Boot 4.0.0
 - Java エコシステムの標準的な Web フレームワーク
 - 組み込み Tomcat で単一 JAR として起動可能
 - REST API を `@RestController` で簡潔に実装できる
 
-#### Maven
-- Spring Initializr のデフォルトビルドツール
-- `pom.xml` が明示的で学習コストが低い
+#### Gradle 8.14
+- Kotlin DSL（`build.gradle.kts`）で型安全なビルド定義が記述できる
+- Spring Boot 4 の依存関係管理プラグイン（`io.spring.dependency-management`）と組み合わせて使用
 
 #### Spring Data JPA + Hibernate
-- Prisma に相当する型安全な DB アクセス層
 - `JpaRepository` を継承するだけで CRUD が実装できる
 - `@Entity` アノテーションでエンティティクラスをテーブルにマッピング
 
-#### Flyway
+#### Flyway 11.3.0
 - 純 SQL 形式のマイグレーションファイル（`V1__create_boards.sql` など）
 - Spring Boot 起動時に自動実行される
-- Liquibase（XML/YAML 形式）より可読性が高い
+- `flyway-database-postgresql` で PostgreSQL 固有の方言をサポート
 
 #### HikariCP
 - Spring Boot の `spring-boot-starter-data-jpa` に同梱されており、追加設定不要
@@ -71,25 +73,26 @@
 
 ### フロントエンド
 
-#### React 18.x
-- コンポーネントベースの UI ライブラリ（安定版）
-- Next.js は使用しない（バックエンドは Spring Boot が担う）
+#### React 19.2.5
+- コンポーネントベースの UI ライブラリ（最新安定版）
+- フロントエンドのみ担当（バックエンドは Spring Boot が担う）
 
-#### Vite 5.x
+#### Vite 8.0.10
 - Create React App（CRA）は非推奨のため Vite を採用
 - ミリ秒単位の高速起動
 - 開発サーバーのプロキシ機能（`/api/*` を Spring Boot の 8080 ポートへ転送）でローカル開発の CORS 問題を解消
 
-#### Axios
+#### TypeScript 6.0.3
+- 型安全な開発でバグを早期発見
+- React コンポーネントの props 型定義が明確になる
+
+#### Axios 1.15.2
 - `fetch` と比較してレスポンスの自動 JSON パースが可能
-- インターセプターで API エラーのトースト表示を一元処理できる
+- インターセプターで API エラーの一元処理ができる
 
 #### useState + Context API
 - Redux は本プロジェクトの規模に対して過剰
 - `BoardContext` にボード全体の状態を集約し、シンプルに管理する
-
-#### React Router v6
-- フェーズ4（複数ボード対応）を見越して `/boards/:boardId` のルーティングを初期から導入
 
 #### @hello-pangea/dnd（フェーズ3）
 - `react-beautiful-dnd`（Atlassian が開発停止）のコミュニティ継続フォーク
@@ -98,7 +101,6 @@
 #### CSS Modules
 - コンポーネントスコープの CSS（グローバル汚染なし）
 - Vite でゼロ設定で動作
-- プロトタイプ（`prototype/index.html`）の CSS をそのまま流用しやすい
 
 ---
 
@@ -121,15 +123,18 @@
 
 ---
 
-## pom.xml 主要依存関係
+## build.gradle.kts 主要依存関係
 
-```xml
-<dependency> spring-boot-starter-web </dependency>
-<dependency> spring-boot-starter-data-jpa </dependency>
-<dependency> spring-boot-starter-validation </dependency>
-<dependency scope="runtime"> postgresql </dependency>
-<dependency> flyway-core </dependency>
-<dependency scope="test"> spring-boot-starter-test </dependency>
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-web")
+implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+implementation("org.springframework.boot:spring-boot-starter-validation")
+implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+runtimeOnly("org.postgresql:postgresql:42.7.4")
+runtimeOnly("com.h2database:h2")
+implementation("org.flywaydb:flyway-core:11.3.0")
+implementation("org.flywaydb:flyway-database-postgresql:11.3.0")
+testImplementation("org.springframework.boot:spring-boot-starter-test")
 ```
 
 ---
@@ -139,20 +144,20 @@
 ```json
 {
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.x",
-    "axios": "^1.x",
-    "react-hot-toast": "^2.x"
+    "axios": "^1.15.2",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
   },
   "devDependencies": {
-    "vite": "^5.x",
-    "@vitejs/plugin-react": "^4.x"
+    "@vitejs/plugin-react": "^6.0.1",
+    "eslint": "^10.2.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10"
   }
 }
 ```
 
-フェーズ3で追加: `"@hello-pangea/dnd": "^16.x"`
+フェーズ3で追加予定: `"@hello-pangea/dnd": "^16.x"`
 
 ---
 
@@ -163,7 +168,7 @@
 docker compose up -d
 
 # 2. バックエンド起動（backend/ ディレクトリで）
-./mvnw spring-boot:run
+./gradlew bootRun
 
 # 3. フロントエンド起動（frontend/ ディレクトリで）
 npm run dev

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Summary

- `frontend/.gitignore` に `.vite` を追加 — Vite の依存プリバンドルキャッシュ（`frontend/.vite/`）が git に追跡されていた問題を修正
- `docs/tech-stack.md` を書き直し — `build.gradle.kts`（Spring Boot 4.0.0, Gradle 8.14, Flyway 11.3.0, PostgreSQL JDBC 42.7.4）と `package.json`（React 19.2.5, Vite 8.0.10, TypeScript 6.0.3, Axios 1.15.2）の実際のバージョンに更新。Maven/React Router/react-hot-toast/Next.js/Supabase/Prisma への誤った参照を削除し、各テーブルにバージョン列を追加
- ルート `README.md` を新規作成 — プロジェクト概要・技術スタック表（バージョン付き）・前提条件・ローカル開発セットアップ・ポート一覧・プロジェクト構造・docs/リンク一覧を含む包括的な README

## Changes

- `frontend/.gitignore` — `.vite` を追加（1行）
- `docs/tech-stack.md` — 全体書き直し（バージョン列追加・誤記削除）
- `README.md` — 新規作成（プロジェクトルート）

Closes #7