### PR TITLE
feat: カード新規登録モーダルUIを実装 (#9)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,3 +1,10 @@
 import axios from 'axios'
+import type { Card, CreateCardRequest } from '../types'
 
-export default axios.create({ baseURL: '/api' })
+const client = axios.create({ baseURL: '/api' })
+
+export function createCard(columnId: string, data: CreateCardRequest): Promise<Card> {
+  return client.post<Card>(`/columns/${columnId}/cards`, data).then((res) => res.data)
+}
+
+export default client

--- a/frontend/src/components/AddCardModal.tsx
+++ b/frontend/src/components/AddCardModal.tsx
@@ -1,0 +1,134 @@
+import { useState, FormEvent } from 'react'
+import { createCard } from '../api/client'
+import type { Card, Priority } from '../types'
+import styles from '../styles/AddCardModal.module.css'
+
+interface Props {
+  columnId: string
+  position: number
+  onSuccess: (card: Card) => void
+  onClose: () => void
+}
+
+export default function AddCardModal({ columnId, position, onSuccess, onClose }: Props) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [priority, setPriority] = useState<Priority>('none')
+  const [titleError, setTitleError] = useState('')
+  const [apiError, setApiError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setTitleError('')
+    setApiError('')
+
+    if (!title.trim()) {
+      setTitleError('タイトルは必須です。')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const card = await createCard(columnId, {
+        title: title.trim(),
+        description: description.trim() || undefined,
+        dueDate: dueDate || undefined,
+        priority,
+        position,
+      })
+      onSuccess(card)
+    } catch {
+      setApiError('カードの作成に失敗しました。もう一度お試しください。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={handleBackdropClick}>
+      <div className={styles.modal}>
+        <p className={styles.title}>新しいカードを追加</p>
+        <form onSubmit={handleSubmit} noValidate>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="card-title">
+                タイトル <span style={{ color: '#e03e3e' }}>*</span>
+              </label>
+              <input
+                id="card-title"
+                className={styles.input}
+                type="text"
+                maxLength={100}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="タスクのタイトルを入力"
+                autoFocus
+              />
+              {titleError && <span className={styles.fieldError}>{titleError}</span>}
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="card-description">
+                説明
+              </label>
+              <textarea
+                id="card-description"
+                className={styles.textarea}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="詳細を入力（任意）"
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="card-dueDate">
+                期限日
+              </label>
+              <input
+                id="card-dueDate"
+                className={styles.input}
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="card-priority">
+                優先度
+              </label>
+              <select
+                id="card-priority"
+                className={styles.select}
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as Priority)}
+              >
+                <option value="none">なし</option>
+                <option value="low">低</option>
+                <option value="medium">中</option>
+                <option value="high">高</option>
+              </select>
+            </div>
+
+            {apiError && <p className={styles.apiError}>{apiError}</p>}
+
+            <div className={styles.actions}>
+              <button type="button" className={styles.btnCancel} onClick={onClose}>
+                キャンセル
+              </button>
+              <button type="submit" className={styles.btnSubmit} disabled={submitting}>
+                {submitting ? '追加中...' : '追加する'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -1,21 +1,48 @@
-import type { BoardColumn } from '../types'
-import Card from './Card'
+import { useState } from 'react'
+import type { BoardColumn, Card } from '../types'
+import CardComponent from './Card'
+import AddCardModal from './AddCardModal'
+import { useBoard } from '../context/BoardContext'
 import styles from '../styles/Column.module.css'
 
 export default function Column({ column }: { column: BoardColumn }) {
+  const { addCard } = useBoard()
+  const [modalOpen, setModalOpen] = useState(false)
   const sorted = [...column.cards].sort((a, b) => a.position - b.position)
+
+  function handleSuccess(card: Card) {
+    addCard(column.id, card)
+    setModalOpen(false)
+  }
 
   return (
     <div className={styles.column}>
       <div className={styles.header}>
         <span className={styles.name}>{column.name}</span>
-        <span className={styles.count}>{sorted.length}</span>
+        <div className={styles.headerRight}>
+          <span className={styles.count}>{sorted.length}</span>
+          <button
+            className={styles.addBtn}
+            onClick={() => setModalOpen(true)}
+            aria-label={`${column.name}にカードを追加`}
+          >
+            +
+          </button>
+        </div>
       </div>
       <div className={styles.cards}>
         {sorted.map((card) => (
-          <Card key={card.id} card={card} />
+          <CardComponent key={card.id} card={card} />
         ))}
       </div>
+      {modalOpen && (
+        <AddCardModal
+          columnId={column.id}
+          position={column.cards.length}
+          onSuccess={handleSuccess}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/context/BoardContext.tsx
+++ b/frontend/src/context/BoardContext.tsx
@@ -1,11 +1,12 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 import client from '../api/client'
-import type { Board } from '../types'
+import type { Board, Card } from '../types'
 
 interface BoardContextValue {
   boards: Board[]
   loading: boolean
   error: string | null
+  addCard: (columnId: string, card: Card) => void
 }
 
 const BoardContext = createContext<BoardContextValue | null>(null)
@@ -25,8 +26,19 @@ export function BoardProvider({ children }: { children: ReactNode }) {
       .finally(() => setLoading(false))
   }, [])
 
+  function addCard(columnId: string, card: Card) {
+    setBoards((prev) =>
+      prev.map((board) => ({
+        ...board,
+        columns: board.columns.map((col) =>
+          col.id === columnId ? { ...col, cards: [...col.cards, card] } : col
+        ),
+      }))
+    )
+  }
+
   return (
-    <BoardContext.Provider value={{ boards, loading, error }}>
+    <BoardContext.Provider value={{ boards, loading, error, addCard }}>
       {children}
     </BoardContext.Provider>
   )

--- a/frontend/src/styles/AddCardModal.module.css
+++ b/frontend/src/styles/AddCardModal.module.css
@@ -1,0 +1,127 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
+  width: 420px;
+  max-width: calc(100vw - 32px);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #555;
+}
+
+.input,
+.textarea,
+.select {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  color: #333;
+  background: #fafafa;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 8px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  border-color: #4a90e2;
+  background: #fff;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.fieldError {
+  font-size: 12px;
+  color: #e03e3e;
+}
+
+.apiError {
+  font-size: 13px;
+  color: #e03e3e;
+  background: #fff5f5;
+  border: 1px solid #fcc;
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.btnCancel {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #666;
+  background: none;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btnCancel:hover {
+  background: #f5f5f5;
+  border-color: #ccc;
+}
+
+.btnSubmit {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  background: #4a90e2;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btnSubmit:hover {
+  background: #357abd;
+}
+
+.btnSubmit:disabled {
+  background: #a0bfe0;
+  cursor: not-allowed;
+}

--- a/frontend/src/styles/Column.module.css
+++ b/frontend/src/styles/Column.module.css
@@ -32,6 +32,29 @@
   border-radius: 10px;
 }
 
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.addBtn {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.addBtn:hover {
+  color: #4a90e2;
+  background: #f0f4ff;
+}
+
 .cards {
   display: flex;
   flex-direction: column;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,3 +22,11 @@ export interface Board {
   name: string
   columns: BoardColumn[]
 }
+
+export interface CreateCardRequest {
+  title: string
+  description?: string
+  dueDate?: string
+  priority: Priority
+  position: number
+}


### PR DESCRIPTION
## Summary
- 各カラムのヘッダーに「+」ボタンを追加し、クリックでモーダルダイアログを表示
- フォーム項目: タイトル（必須）、説明、期限日、優先度セレクト
- 送信後、`POST /api/columns/{columnId}/cards` でカードを作成し、ページリロードなしで即時表示
- タイトル未入力時はクライアントサイドバリデーションでエラー表示
- API失敗時はモーダル内にエラーメッセージ表示

## Changes
- `types.ts` — `CreateCardRequest` 型を追加
- `api/client.ts` — `createCard()` 関数を追加
- `context/BoardContext.tsx` — `addCard()` をコンテキストに追加（immutable state更新）
- `components/AddCardModal.tsx` — モーダルコンポーネントを新規作成
- `styles/AddCardModal.module.css` — モーダルのスタイル（既存デザイン規則に準拠）
- `components/Column.tsx` — +ボタンとモーダル連携を追加
- `styles/Column.module.css` — `.headerRight` と `.addBtn` スタイルを追加

## Test plan
- [x] 各カラムのヘッダーに「+」ボタンが表示されること
- [x] 「+」クリックでモーダルが開くこと
- [x] タイトル空で送信するとバリデーションエラーが表示されること
- [x] タイトル入力して送信するとモーダルが閉じ、カラム末尾にカードが即時追加されること
- [x] ページリロード後もカードが永続されていること（DB保存確認）
- [x] 背景クリックでモーダルが閉じること

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)