### PR TITLE
fix: ソート中のカードD&D列間移動を修正 (#13)

### DIFF
--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -68,25 +68,21 @@ export default function Column({ column, index }: Props) {
                 {...dropProvided.droppableProps}
               >
                 {sorted.map((card, cardIndex) => (
-                  sortMode === 'manual' ? (
-                    <Draggable key={card.id} draggableId={card.id} index={cardIndex}>
-                      {(cardProvided, cardSnapshot) => (
-                        <div
-                          ref={cardProvided.innerRef}
-                          {...cardProvided.draggableProps}
-                          {...cardProvided.dragHandleProps}
-                          style={{
-                            ...cardProvided.draggableProps.style,
-                            opacity: cardSnapshot.isDragging ? 0.7 : 1,
-                          }}
-                        >
-                          <CardComponent card={card} onEdit={setEditingCard} />
-                        </div>
-                      )}
-                    </Draggable>
-                  ) : (
-                    <CardComponent key={card.id} card={card} onEdit={setEditingCard} />
-                  )
+                  <Draggable key={card.id} draggableId={card.id} index={cardIndex}>
+                    {(cardProvided, cardSnapshot) => (
+                      <div
+                        ref={cardProvided.innerRef}
+                        {...cardProvided.draggableProps}
+                        {...cardProvided.dragHandleProps}
+                        style={{
+                          ...cardProvided.draggableProps.style,
+                          opacity: cardSnapshot.isDragging ? 0.7 : 1,
+                        }}
+                      >
+                        <CardComponent card={card} onEdit={setEditingCard} />
+                      </div>
+                    )}
+                  </Draggable>
                 ))}
                 {dropProvided.placeholder}
               </div>

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -56,9 +56,10 @@ export default function KanbanBoard() {
     const toColumn = sortedColumns.find((c) => c.id === destination.droppableId)
     if (!fromColumn || !toColumn) return
 
-    const fromCards = [...fromColumn.cards].sort((a, b) => a.position - b.position)
-    const movedCard = fromCards[source.index]
+    const movedCard = fromColumn.cards.find((c) => c.id === result.draggableId)
     if (!movedCard) return
+
+    const fromCards = [...fromColumn.cards].sort((a, b) => a.position - b.position)
 
     if (source.droppableId === destination.droppableId) {
       // 同一列内の並び替え


### PR DESCRIPTION
## Summary

- ソートモード（優先度順・期限順）中も常に `Draggable` でラップし、列間D&Dを有効化
- `source.index`（表示上の順序）の代わりに `result.draggableId` でカードを特定することで、表示順と position 順のズレによる「別のカードが移動される」バグを修正

## Root cause

ソートモード中、`source.index` は表示上（ソート後）のインデックスだが、`fromCards` は `position` 順でソートされていたため、インデックスがズレて意図しないカードが選ばれていた。

## Test plan

- [x] 優先度順ソート中にカードを別の列にD&D → 正しいカードが移動する
- [x] 期限順ソート中にカードを別の列にD&D → 正しいカードが移動する
- [x] 手動モードでのD&Dは引き続き正常に動作する

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)