### PR TITLE
feat: カード削除機能を実装 (#15)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,4 +25,8 @@ export function moveCard(cardId: string, newColumnId: string): Promise<Card> {
   return client.patch<Card>(`/cards/${cardId}/move`, null, { params: { columnId: newColumnId } }).then((res) => res.data)
 }
 
+export function deleteCard(id: string): Promise<void> {
+  return client.delete(`/cards/${id}`).then(() => undefined)
+}
+
 export default client

--- a/frontend/src/components/EditCardModal.tsx
+++ b/frontend/src/components/EditCardModal.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function EditCardModal({ card, columnId, onClose }: Props) {
-  const { updateCardInContext } = useBoard()
+  const { updateCardInContext, deleteCard } = useBoard()
   const [title, setTitle] = useState(card.title)
   const [description, setDescription] = useState(card.description ?? '')
   const [dueDate, setDueDate] = useState(card.dueDate ?? '')
@@ -19,6 +19,7 @@ export default function EditCardModal({ card, columnId, onClose }: Props) {
   const [titleError, setTitleError] = useState('')
   const [apiError, setApiError] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -44,6 +45,18 @@ export default function EditCardModal({ card, columnId, onClose }: Props) {
       setApiError('カードの更新に失敗しました。もう一度お試しください。')
     } finally {
       setSubmitting(false)
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    setApiError('')
+    try {
+      await deleteCard(columnId, card.id)
+      onClose()
+    } catch {
+      setApiError('カードの削除に失敗しました。もう一度お試しください。')
+      setDeleting(false)
     }
   }
 
@@ -120,12 +133,22 @@ export default function EditCardModal({ card, columnId, onClose }: Props) {
             {apiError && <p className={styles.apiError}>{apiError}</p>}
 
             <div className={styles.actions}>
-              <button type="button" className={styles.btnCancel} onClick={onClose}>
-                キャンセル
+              <button
+                type="button"
+                className={styles.btnDelete}
+                onClick={handleDelete}
+                disabled={deleting || submitting}
+              >
+                {deleting ? '削除中...' : '削除する'}
               </button>
-              <button type="submit" className={styles.btnSubmit} disabled={submitting}>
-                {submitting ? '保存中...' : '保存する'}
-              </button>
+              <div style={{ marginLeft: 'auto', display: 'flex', gap: '8px' }}>
+                <button type="button" className={styles.btnCancel} onClick={onClose} disabled={deleting}>
+                  キャンセル
+                </button>
+                <button type="submit" className={styles.btnSubmit} disabled={submitting || deleting}>
+                  {submitting ? '保存中...' : '保存する'}
+                </button>
+              </div>
             </div>
           </div>
         </form>

--- a/frontend/src/context/BoardContext.tsx
+++ b/frontend/src/context/BoardContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
 import client from '../api/client'
+import { deleteCard as deleteCardApi } from '../api/client'
 import type { Board, BoardColumn, Card } from '../types'
 
 interface BoardContextValue {
@@ -12,6 +13,7 @@ interface BoardContextValue {
   reorderColumns: (newColumns: BoardColumn[]) => void
   reorderCardsInColumn: (columnId: string, newCards: Card[]) => void
   refreshBoard: () => Promise<void>
+  deleteCard: (columnId: string, cardId: string) => Promise<void>
 }
 
 const BoardContext = createContext<BoardContextValue | null>(null)
@@ -97,6 +99,18 @@ export function BoardProvider({ children }: { children: ReactNode }) {
     )
   }
 
+  async function deleteCard(columnId: string, cardId: string): Promise<void> {
+    await deleteCardApi(cardId)
+    setBoards((prev) =>
+      prev.map((board) => ({
+        ...board,
+        columns: board.columns.map((col) =>
+          col.id === columnId ? { ...col, cards: col.cards.filter((c) => c.id !== cardId) } : col
+        ),
+      }))
+    )
+  }
+
   return (
     <BoardContext.Provider
       value={{
@@ -109,6 +123,7 @@ export function BoardProvider({ children }: { children: ReactNode }) {
         reorderColumns,
         reorderCardsInColumn,
         refreshBoard,
+        deleteCard,
       }}
     >
       {children}

--- a/frontend/src/styles/EditCardModal.module.css
+++ b/frontend/src/styles/EditCardModal.module.css
@@ -125,3 +125,26 @@
   background: #a0bfe0;
   cursor: not-allowed;
 }
+
+.btnDelete {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #e53935;
+  background: none;
+  border: 1px solid #e53935;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.btnDelete:hover {
+  background: #fde8e8;
+}
+
+.btnDelete:disabled {
+  color: #ef9a9a;
+  border-color: #ef9a9a;
+  cursor: not-allowed;
+}

--- a/frontend/src/styles/KanbanBoard.module.css
+++ b/frontend/src/styles/KanbanBoard.module.css
@@ -72,3 +72,4 @@
   color: #e53935;
   font-size: 15px;
 }
+


### PR DESCRIPTION
## Summary
- カード編集モーダル（EditCardModal）の左下に「削除する」ボタンを追加
- `DELETE /api/cards/{id}` を呼び出してカードを物理削除
- 削除後はモーダルを閉じ、コンテキストからカードを即時除去

## 変更ファイル
- `frontend/src/api/client.ts` — `deleteCard` named export を追加
- `frontend/src/context/BoardContext.tsx` — `deleteCard` をインターフェース・実装・Provider value に追加
- `frontend/src/components/EditCardModal.tsx` — 削除ボタンと `handleDelete` を追加
- `frontend/src/styles/EditCardModal.module.css` — `.btnDelete` スタイルを追加

## Test plan
- [x] カードをクリックして編集モーダルを開く
- [x] モーダル左下に「削除する」ボタンが表示されることを確認
- [x] 「削除する」クリックでカードがボードから消えることを確認
- [x] 「キャンセル」ではカードが残ることを確認
- [x] DB で対象カードが物理削除されていることを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)