### PR TITLE
docs: fix project name typo (TaskuManegement → TaskManagement) (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ UI は `http://localhost:5173` で利用可能。Vite が `/api/*` リクエス�
 ## プロジェクト構造
 
 ```
-TaskuManegement/
+TaskManagement/
 ├── backend/                        # Spring Boot 4 アプリケーション
 │   ├── src/main/java/              # Java ソース（controllers, services, repositories）
 │   ├── src/main/resources/


### PR DESCRIPTION
## Summary
- `README.md` のプロジェクト構造図の `TaskuManegement/` を `TaskManagement/` に修正

## Test plan
- [ ] README.md の83行目が `TaskManagement/` になっていることを確認

Closes #21