### PR TITLE
feat: 列・ボードの追加UIを実装 (#23)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Card, BoardColumn, CreateCardRequest } from '../types'
+import type { Card, BoardColumn, Board, CreateCardRequest, CreateColumnRequest, CreateBoardRequest } from '../types'
 
 const client = axios.create({ baseURL: '/api' })
 
@@ -27,6 +27,14 @@ export function moveCard(cardId: string, newColumnId: string): Promise<Card> {
 
 export function deleteCard(id: string): Promise<void> {
   return client.delete(`/cards/${id}`).then(() => undefined)
+}
+
+export function createColumn(boardId: string, data: CreateColumnRequest): Promise<BoardColumn> {
+  return client.post<BoardColumn>(`/boards/${boardId}/columns`, data).then((res) => res.data)
+}
+
+export function createBoard(data: CreateBoardRequest): Promise<Board> {
+  return client.post<Board>('/boards', data).then((res) => res.data)
 }
 
 export default client

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -37,4 +37,8 @@ export function createBoard(data: CreateBoardRequest): Promise<Board> {
   return client.post<Board>('/boards', data).then((res) => res.data)
 }
 
+export function deleteColumn(id: string): Promise<void> {
+  return client.delete(`/columns/${id}`).then(() => undefined)
+}
+
 export default client

--- a/frontend/src/components/AddBoardModal.tsx
+++ b/frontend/src/components/AddBoardModal.tsx
@@ -1,0 +1,80 @@
+import { useState, FormEvent, MouseEvent } from 'react'
+import { createBoard } from '../api/client'
+import type { Board } from '../types'
+import styles from '../styles/AddCardModal.module.css'
+
+interface Props {
+  onSuccess: (board: Board) => void
+  onClose: () => void
+}
+
+export default function AddBoardModal({ onSuccess, onClose }: Props) {
+  const [name, setName] = useState('')
+  const [nameError, setNameError] = useState('')
+  const [apiError, setApiError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setNameError('')
+    setApiError('')
+
+    if (!name.trim()) {
+      setNameError('ボード名は必須です。')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const board = await createBoard({ name: name.trim() })
+      onSuccess(board)
+    } catch {
+      setApiError('ボードの作成に失敗しました。もう一度お試しください。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handleBackdropClick(e: MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={handleBackdropClick}>
+      <div className={styles.modal}>
+        <p className={styles.title}>新しいボードを追加</p>
+        <form onSubmit={handleSubmit} noValidate>
+          <div className={styles.formFields}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="board-name">
+                ボード名 <span className={styles.required}>*</span>
+              </label>
+              <input
+                id="board-name"
+                className={styles.input}
+                type="text"
+                maxLength={100}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="ボードの名前を入力"
+                autoFocus
+              />
+              {nameError && <span className={styles.fieldError}>{nameError}</span>}
+            </div>
+
+            {apiError && <p className={styles.apiError}>{apiError}</p>}
+
+            <div className={styles.actions}>
+              <button type="button" className={styles.btnCancel} onClick={onClose}>
+                キャンセル
+              </button>
+              <button type="submit" className={styles.btnSubmit} disabled={submitting}>
+                {submitting ? '追加中...' : '追加する'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/AddColumnModal.tsx
+++ b/frontend/src/components/AddColumnModal.tsx
@@ -1,0 +1,82 @@
+import { useState, FormEvent, MouseEvent } from 'react'
+import { createColumn } from '../api/client'
+import type { BoardColumn } from '../types'
+import styles from '../styles/AddCardModal.module.css'
+
+interface Props {
+  boardId: string
+  position: number
+  onSuccess: (column: BoardColumn) => void
+  onClose: () => void
+}
+
+export default function AddColumnModal({ boardId, position, onSuccess, onClose }: Props) {
+  const [name, setName] = useState('')
+  const [nameError, setNameError] = useState('')
+  const [apiError, setApiError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setNameError('')
+    setApiError('')
+
+    if (!name.trim()) {
+      setNameError('列名は必須です。')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const column = await createColumn(boardId, { name: name.trim(), position })
+      onSuccess(column)
+    } catch {
+      setApiError('列の作成に失敗しました。もう一度お試しください。')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handleBackdropClick(e: MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={handleBackdropClick}>
+      <div className={styles.modal}>
+        <p className={styles.title}>新しい列を追加</p>
+        <form onSubmit={handleSubmit} noValidate>
+          <div className={styles.formFields}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="column-name">
+                列名 <span className={styles.required}>*</span>
+              </label>
+              <input
+                id="column-name"
+                className={styles.input}
+                type="text"
+                maxLength={50}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="列の名前を入力"
+                autoFocus
+              />
+              {nameError && <span className={styles.fieldError}>{nameError}</span>}
+            </div>
+
+            {apiError && <p className={styles.apiError}>{apiError}</p>}
+
+            <div className={styles.actions}>
+              <button type="button" className={styles.btnCancel} onClick={onClose}>
+                キャンセル
+              </button>
+              <button type="submit" className={styles.btnSubmit} disabled={submitting}>
+                {submitting ? '追加中...' : '追加する'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -11,10 +11,12 @@ import styles from '../styles/Column.module.css'
 interface Props {
   column: BoardColumn
   index: number
+  onDelete: () => Promise<void>
 }
 
-export default function Column({ column, index }: Props) {
+export default function Column({ column, index, onDelete }: Props) {
   const { addCard } = useBoard()
+  const [deleting, setDeleting] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [editingCard, setEditingCard] = useState<Card | null>(null)
   const [sortMode, setSortMode] = useState<CardSortMode>('manual')
@@ -24,6 +26,16 @@ export default function Column({ column, index }: Props) {
   function handleSuccess(card: Card) {
     addCard(column.id, card)
     setModalOpen(false)
+  }
+
+  async function handleDelete() {
+    if (!window.confirm(`「${column.name}」を削除しますか？\nこの列のカードもすべて削除されます。`)) return
+    setDeleting(true)
+    try {
+      await onDelete()
+    } finally {
+      setDeleting(false)
+    }
   }
 
   return (
@@ -57,6 +69,14 @@ export default function Column({ column, index }: Props) {
                 aria-label={`${column.name}にカードを追加`}
               >
                 +
+              </button>
+              <button
+                className={styles.deleteBtn}
+                onClick={handleDelete}
+                disabled={deleting}
+                aria-label={`${column.name}を削除`}
+              >
+                ×
               </button>
             </div>
           </div>

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,11 +1,17 @@
+import { useState } from 'react'
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd'
 import { useBoard } from '../context/BoardContext'
 import Column from './Column'
+import AddColumnModal from './AddColumnModal'
+import AddBoardModal from './AddBoardModal'
 import { updateCard, updateColumn, moveCard } from '../api/client'
+import type { BoardColumn, Board } from '../types'
 import styles from '../styles/KanbanBoard.module.css'
 
 export default function KanbanBoard() {
-  const { boards, loading, error, reorderColumns, reorderCardsInColumn, moveCardInContext, refreshBoard } = useBoard()
+  const { boards, loading, error, reorderColumns, reorderCardsInColumn, moveCardInContext, refreshBoard, addColumn, addBoard } = useBoard()
+  const [addColumnModalOpen, setAddColumnModalOpen] = useState(false)
+  const [addBoardModalOpen, setAddBoardModalOpen] = useState(false)
 
   if (loading) {
     return (
@@ -106,11 +112,27 @@ export default function KanbanBoard() {
     }
   }
 
+  function handleColumnAdded(column: BoardColumn) {
+    addColumn(board.id, column)
+    setAddColumnModalOpen(false)
+  }
+
+  function handleBoardAdded(newBoard: Board) {
+    addBoard(newBoard)
+    setAddBoardModalOpen(false)
+  }
+
   return (
     <div className={styles.wrapper}>
       <header className={styles.header}>
         <h1 className={styles.title}>タスク<strong>ボード</strong></h1>
         <span className={styles.boardName}>{board.name}</span>
+        <button
+          className={styles.addBoardBtn}
+          onClick={() => setAddBoardModalOpen(true)}
+        >
+          + ボードを追加
+        </button>
       </header>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="column" direction="horizontal">
@@ -124,10 +146,30 @@ export default function KanbanBoard() {
                 <Column key={col.id} column={col} index={index} />
               ))}
               {provided.placeholder}
+              <button
+                className={styles.addColumnBtn}
+                onClick={() => setAddColumnModalOpen(true)}
+              >
+                + 列を追加
+              </button>
             </div>
           )}
         </Droppable>
       </DragDropContext>
+      {addColumnModalOpen && (
+        <AddColumnModal
+          boardId={board.id}
+          position={sortedColumns.length}
+          onSuccess={handleColumnAdded}
+          onClose={() => setAddColumnModalOpen(false)}
+        />
+      )}
+      {addBoardModalOpen && (
+        <AddBoardModal
+          onSuccess={handleBoardAdded}
+          onClose={() => setAddBoardModalOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -9,7 +9,7 @@ import type { BoardColumn, Board } from '../types'
 import styles from '../styles/KanbanBoard.module.css'
 
 export default function KanbanBoard() {
-  const { boards, loading, error, reorderColumns, reorderCardsInColumn, moveCardInContext, refreshBoard, addColumn, addBoard } = useBoard()
+  const { boards, currentBoardIndex, setCurrentBoardIndex, loading, error, reorderColumns, reorderCardsInColumn, moveCardInContext, refreshBoard, addColumn, addBoard, deleteColumn } = useBoard()
   const [addColumnModalOpen, setAddColumnModalOpen] = useState(false)
   const [addBoardModalOpen, setAddBoardModalOpen] = useState(false)
 
@@ -30,7 +30,7 @@ export default function KanbanBoard() {
     return <div className={styles.center}>ボードがありません。</div>
   }
 
-  const board = boards[0]
+  const board = boards[currentBoardIndex] ?? boards[0]
   const sortedColumns = [...board.columns].sort((a, b) => a.position - b.position)
 
   async function handleDragEnd(result: DropResult) {
@@ -126,7 +126,15 @@ export default function KanbanBoard() {
     <div className={styles.wrapper}>
       <header className={styles.header}>
         <h1 className={styles.title}>タスク<strong>ボード</strong></h1>
-        <span className={styles.boardName}>{board.name}</span>
+        <select
+          className={styles.boardSelect}
+          value={currentBoardIndex}
+          onChange={(e) => setCurrentBoardIndex(Number(e.target.value))}
+        >
+          {boards.map((b, i) => (
+            <option key={b.id} value={i}>{b.name}</option>
+          ))}
+        </select>
         <button
           className={styles.addBoardBtn}
           onClick={() => setAddBoardModalOpen(true)}
@@ -143,7 +151,12 @@ export default function KanbanBoard() {
               {...provided.droppableProps}
             >
               {sortedColumns.map((col, index) => (
-                <Column key={col.id} column={col} index={index} />
+                <Column
+                  key={col.id}
+                  column={col}
+                  index={index}
+                  onDelete={() => deleteColumn(board.id, col.id)}
+                />
               ))}
               {provided.placeholder}
               <button

--- a/frontend/src/context/BoardContext.tsx
+++ b/frontend/src/context/BoardContext.tsx
@@ -14,6 +14,8 @@ interface BoardContextValue {
   reorderCardsInColumn: (columnId: string, newCards: Card[]) => void
   refreshBoard: () => Promise<void>
   deleteCard: (columnId: string, cardId: string) => Promise<void>
+  addColumn: (boardId: string, column: BoardColumn) => void
+  addBoard: (board: Board) => void
 }
 
 const BoardContext = createContext<BoardContextValue | null>(null)
@@ -111,6 +113,20 @@ export function BoardProvider({ children }: { children: ReactNode }) {
     )
   }
 
+  function addColumn(boardId: string, column: BoardColumn) {
+    setBoards((prev) =>
+      prev.map((board) =>
+        board.id === boardId
+          ? { ...board, columns: [...board.columns, column] }
+          : board
+      )
+    )
+  }
+
+  function addBoard(board: Board) {
+    setBoards((prev) => [...prev, board])
+  }
+
   return (
     <BoardContext.Provider
       value={{
@@ -124,6 +140,8 @@ export function BoardProvider({ children }: { children: ReactNode }) {
         reorderCardsInColumn,
         refreshBoard,
         deleteCard,
+        addColumn,
+        addBoard,
       }}
     >
       {children}

--- a/frontend/src/context/BoardContext.tsx
+++ b/frontend/src/context/BoardContext.tsx
@@ -1,10 +1,12 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
 import client from '../api/client'
-import { deleteCard as deleteCardApi } from '../api/client'
+import { deleteCard as deleteCardApi, deleteColumn as deleteColumnApi } from '../api/client'
 import type { Board, BoardColumn, Card } from '../types'
 
 interface BoardContextValue {
   boards: Board[]
+  currentBoardIndex: number
+  setCurrentBoardIndex: (index: number) => void
   loading: boolean
   error: string | null
   addCard: (columnId: string, card: Card) => void
@@ -16,12 +18,14 @@ interface BoardContextValue {
   deleteCard: (columnId: string, cardId: string) => Promise<void>
   addColumn: (boardId: string, column: BoardColumn) => void
   addBoard: (board: Board) => void
+  deleteColumn: (boardId: string, columnId: string) => Promise<void>
 }
 
 const BoardContext = createContext<BoardContextValue | null>(null)
 
 export function BoardProvider({ children }: { children: ReactNode }) {
   const [boards, setBoards] = useState<Board[]>([])
+  const [currentBoardIndex, setCurrentBoardIndex] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -124,13 +128,30 @@ export function BoardProvider({ children }: { children: ReactNode }) {
   }
 
   function addBoard(board: Board) {
-    setBoards((prev) => [...prev, board])
+    setBoards((prev) => {
+      const next = [...prev, board]
+      setCurrentBoardIndex(next.length - 1)
+      return next
+    })
+  }
+
+  async function deleteColumn(boardId: string, columnId: string): Promise<void> {
+    await deleteColumnApi(columnId)
+    setBoards((prev) =>
+      prev.map((board) =>
+        board.id === boardId
+          ? { ...board, columns: board.columns.filter((col) => col.id !== columnId) }
+          : board
+      )
+    )
   }
 
   return (
     <BoardContext.Provider
       value={{
         boards,
+        currentBoardIndex,
+        setCurrentBoardIndex,
         loading,
         error,
         addCard,
@@ -142,6 +163,7 @@ export function BoardProvider({ children }: { children: ReactNode }) {
         deleteCard,
         addColumn,
         addBoard,
+        deleteColumn,
       }}
     >
       {children}

--- a/frontend/src/styles/Column.module.css
+++ b/frontend/src/styles/Column.module.css
@@ -88,6 +88,28 @@
   background: #f0f4ff;
 }
 
+.deleteBtn {
+  background: none;
+  border: none;
+  color: #bbb;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.deleteBtn:hover {
+  color: #e53935;
+  background: #fff0f0;
+}
+
+.deleteBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .cards {
   display: flex;
   flex-direction: column;

--- a/frontend/src/styles/KanbanBoard.module.css
+++ b/frontend/src/styles/KanbanBoard.module.css
@@ -73,6 +73,24 @@
   font-size: 15px;
 }
 
+.boardSelect {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 5px 10px;
+  cursor: pointer;
+  outline: none;
+}
+
+.boardSelect:focus {
+  border-color: #4a90e2;
+  background: #fff;
+}
+
 .addBoardBtn {
   margin-left: auto;
   padding: 6px 14px;

--- a/frontend/src/styles/KanbanBoard.module.css
+++ b/frontend/src/styles/KanbanBoard.module.css
@@ -73,3 +73,40 @@
   font-size: 15px;
 }
 
+.addBoardBtn {
+  margin-left: auto;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #4a90e2;
+  background: #fff;
+  border: 1px solid #4a90e2;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.addBoardBtn:hover {
+  background: #4a90e2;
+  color: #fff;
+}
+
+.addColumnBtn {
+  flex-shrink: 0;
+  width: 220px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #4a90e2;
+  background: rgba(74, 144, 226, 0.06);
+  border: 2px dashed #4a90e2;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  align-self: flex-start;
+}
+
+.addColumnBtn:hover {
+  background: rgba(74, 144, 226, 0.14);
+}
+

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -32,3 +32,12 @@ export interface CreateCardRequest {
 }
 
 export type CardSortMode = 'manual' | 'priority' | 'dueDate'
+
+export interface CreateColumnRequest {
+  name: string
+  position: number
+}
+
+export interface CreateBoardRequest {
+  name: string
+}


### PR DESCRIPTION
## 概要

バックエンドに実装済みの列・ボード作成APIに対応するフロントエンドUIを追加します。

Closes #23

## 変更内容

- KanbanBoard ヘッダーに「+ ボードを追加」ボタンを追加
- ボード列の末尾に「+ 列を追加」ボタンを追加（ドラッグ対象外）
- `AddColumnModal` コンポーネントを新規作成
- `AddBoardModal` コンポーネントを新規作成
- `BoardContext` に `addColumn` / `addBoard` 関数を追加
- `api/client.ts` に `createColumn` / `createBoard` 関数を追加
- `types.ts` に `CreateColumnRequest` / `CreateBoardRequest` 型を追加

## テスト

- [x] `npm run lint` — エラーなし
- [x] `npm run type-check` — エラーなし
- [x] `npm run build` — 成功